### PR TITLE
RTD MAX31865Class private _ch_sel1 assignment fixed to channel 1

### DIFF
--- a/src/RTDTempProbeClass.cpp
+++ b/src/RTDTempProbeClass.cpp
@@ -20,7 +20,7 @@ RTDTempProbeClass::RTDTempProbeClass(PinName rtd_cs_pin,
                                      PinName ch_sel1_pin,
                                      PinName ch_sel2_pin,
                                      PinName rtd_th_pin)
-: MAX31865Class(rtd_cs_pin), _rtd_cs{rtd_cs_pin}, _ch_sel0{ch_sel0_pin}, _ch_sel1{ch_sel0_pin}, _ch_sel2{ch_sel2_pin}, _rtd_th{rtd_th_pin}                     
+: MAX31865Class(rtd_cs_pin), _rtd_cs{rtd_cs_pin}, _ch_sel0{ch_sel0_pin}, _ch_sel1{ch_sel1_pin}, _ch_sel2{ch_sel2_pin}, _rtd_th{rtd_th_pin}                     
 { }
 
 RTDTempProbeClass::~RTDTempProbeClass() 


### PR DESCRIPTION
Hot fix regarding channel 1 of the RTD sensor pins

Channel 1 was not working properly due to a small typo in the assignments

![image](https://github.com/arduino-libraries/Arduino_PortentaMachineControl/assets/7687624/85ad6175-b029-49d7-bb8a-8877c7cb8bd2)

Now the problem has been fixed and the sensors are working again on channel 2:

![image](https://github.com/arduino-libraries/Arduino_PortentaMachineControl/assets/7687624/1499d525-1faa-45ea-adaa-23e2a0d04bd6)
