### PR TITLE
Thermocouple reading issue CH1 Update TCTempProbeClass.cpp

### DIFF
--- a/src/TCTempProbeClass.cpp
+++ b/src/TCTempProbeClass.cpp
@@ -19,7 +19,7 @@ TCTempProbeClass::TCTempProbeClass(PinName tc_cs_pin,
                                      PinName ch_sel0_pin, 
                                      PinName ch_sel1_pin,
                                      PinName ch_sel2_pin)
-: MAX31855Class(tc_cs_pin), _tc_cs{tc_cs_pin}, _ch_sel0{ch_sel0_pin}, _ch_sel1{ch_sel0_pin}, _ch_sel2{ch_sel2_pin}                  
+: MAX31855Class(tc_cs_pin), _tc_cs{tc_cs_pin}, _ch_sel0{ch_sel0_pin}, _ch_sel1{ch_sel1_pin}, _ch_sel2{ch_sel2_pin}                  
 { }
 
 TCTempProbeClass::~TCTempProbeClass() 


### PR DESCRIPTION
The Class argument was wrong pointing to a wrong pin, it was fixed and tested.