### PR TITLE
Add method to change encoder encoding type.

### DIFF
--- a/src/EncoderClass.cpp
+++ b/src/EncoderClass.cpp
@@ -63,5 +63,14 @@ int EncoderClass::getRevolutions(int channel) {
     }
 }
 
+void EncoderClass::setEncoding(int channel, QEI::Encoding encoding) {
+    switch (channel) {
+        case 0:
+            return _enc0.setEncoding(encoding);
+        case 1:
+            return _enc1.setEncoding(encoding);
+    }
+}
+
 EncoderClass MachineControl_Encoders;
 /**** END OF FILE ****/

--- a/src/EncoderClass.h
+++ b/src/EncoderClass.h
@@ -94,6 +94,16 @@ public:
      */
     int getRevolutions(int channel);
 
+    /**
+     * @brief Set the encoding type for the specified encoder channel.
+     * 
+     * This method changes the encoding type from the default X2_ENCODING.
+     * 
+     * @param channel The encoder channel (0 or 1) to be changed.
+     * @param encoding The encoding type.
+     */
+    void setEncoding(int channel, QEI::Encoding encoding);
+
 private:
     QEI _enc0;  // QEI object for encoder 0
     QEI _enc1;  // QEI object for encoder 1

--- a/src/utility/QEI/QEI.cpp
+++ b/src/utility/QEI/QEI.cpp
@@ -148,19 +148,7 @@ QEI::QEI(PinName channelA,
     currState_ = (chanA << 1) | (chanB);
     prevState_ = currState_;
 
-    //X2 encoding uses interrupts on only channel A.
-    //X4 encoding uses interrupts on      channel A,
-    //and on channel B.
-    channelA_.rise(mbed::callback(this, &QEI::encode));
-    if(encoding != X1_ENCODING){
-        channelA_.fall(mbed::callback(this, &QEI::encode));
-    }
-
-    //If we're using X4 encoding, then attach interrupts to channel B too.
-    if (encoding == X4_ENCODING) {
-        channelB_.rise(mbed::callback(this, &QEI::encode));
-        channelB_.fall(mbed::callback(this, &QEI::encode));
-    }
+    setEncoding(encoding);
     //Index is optional.
     if (index !=  NC) {
         index_.rise(mbed::callback(this, &QEI::index));
@@ -191,6 +179,24 @@ int QEI::getRevolutions(void) {
 
     return revolutions_;
 
+}
+
+void QEI::setEncoding(Encoding encoding) {
+    //X2 encoding uses interrupts on only channel A.
+    //X4 encoding uses interrupts on      channel A,
+    //and on channel B.
+    channelA_.rise(mbed::callback(this, &QEI::encode));
+    if(encoding != X1_ENCODING){
+        channelA_.fall(mbed::callback(this, &QEI::encode));
+    } else {
+        channelA_.fall(0);
+    }
+
+    //If we're using X4 encoding, then attach interrupts to channel B too.
+    if (encoding == X4_ENCODING) {
+        channelB_.rise(mbed::callback(this, &QEI::encode));
+        channelB_.fall(mbed::callback(this, &QEI::encode));
+    }
 }
 
 // +-------------+

--- a/src/utility/QEI/QEI.h
+++ b/src/utility/QEI/QEI.h
@@ -176,7 +176,7 @@ public:
      *                 of only channel A where as X4 uses them on both
      *                 channels.
      */
-    QEI(PinName channelA, PinName channelB, PinName index, int pulsesPerRev, Encoding encoding = X2_ENCODING);
+    QEI(PinName channelA, PinName channelB, PinName index, int pulsesPerRev, Encoding encoding = X4_ENCODING);
 
     /**
      * Reset the encoder.
@@ -207,6 +207,13 @@ public:
      * @return Number of revolutions which have occured on the index channel.
      */
     int getRevolutions(void);
+
+    /**
+     * Set the ecoding type of the encoder.
+     * 
+     * Changes the type of encoding used by the encoder from the default X2_ENCODING.
+     */
+    void setEncoding(Encoding encoding);
 
 private:
 


### PR DESCRIPTION
The MachineControl_Encoders class defaults to X2 encoding and provides no way to change to X1 or X4. This change implements the _setEncoding()_ to support changing the encoding type.